### PR TITLE
Upgrade: C++ Build Tools v145 fixes

### DIFF
--- a/.github/workflows/msbuild.yml
+++ b/.github/workflows/msbuild.yml
@@ -13,7 +13,7 @@ jobs:
     name: Create Release
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
 
     - name: Generate changelog
       id: changelog
@@ -32,14 +32,14 @@ jobs:
         prerelease: true
         
   build:
-    runs-on: windows-latest
+    runs-on: windows-2025-vs2026
     strategy:
       fail-fast: false
       matrix:
         configuration: [ Release, ReleaseTrace, ReleaseNoArch, ReleaseTraceNoArch ]
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
 
     - name: Add MSBuild to PATH
       uses: microsoft/setup-msbuild@v2

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,14 +12,14 @@ permissions:
 
 jobs:
   build:
-    runs-on: windows-latest
+    runs-on: windows-2025-vs2026
     strategy:
       fail-fast: false
       matrix:
         configuration: [ Debug, Release, ReleaseTrace, ReleaseNoArch, ReleaseTraceNoArch ]
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
 
     - name: Add MSBuild to PATH
       uses: microsoft/setup-msbuild@v2

--- a/.gitignore
+++ b/.gitignore
@@ -275,3 +275,4 @@ git_hash.h
 venv/
 
 vcpkg_installed/
+.github/upgrades/scenarios

--- a/DeckLink/DeckLink.vcxproj
+++ b/DeckLink/DeckLink.vcxproj
@@ -47,40 +47,40 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
     <ConfigurationType>StaticLibrary</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>v143</PlatformToolset>
+    <PlatformToolset>v145</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
     <ConfigurationType>StaticLibrary</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>v143</PlatformToolset>
+    <PlatformToolset>v145</PlatformToolset>
     <WholeProgramOptimization>true</WholeProgramOptimization>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='ReleaseNoArch|Win32'" Label="Configuration">
     <ConfigurationType>StaticLibrary</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>v143</PlatformToolset>
+    <PlatformToolset>v145</PlatformToolset>
     <WholeProgramOptimization>true</WholeProgramOptimization>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
     <ConfigurationType>StaticLibrary</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>v143</PlatformToolset>
+    <PlatformToolset>v145</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
     <ConfigurationType>StaticLibrary</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>v143</PlatformToolset>
+    <PlatformToolset>v145</PlatformToolset>
     <WholeProgramOptimization>true</WholeProgramOptimization>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='ReleaseNoArch|x64'" Label="Configuration">
     <ConfigurationType>StaticLibrary</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>v143</PlatformToolset>
+    <PlatformToolset>v145</PlatformToolset>
     <WholeProgramOptimization>true</WholeProgramOptimization>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>

--- a/assessment.md
+++ b/assessment.md
@@ -1,0 +1,67 @@
+C++ Build Tools Upgrade - Assessment
+
+Summary
+
+- Solution: C:\Users\matt\source\repos\3ll3d00d\mwcapture\ezcapture.sln
+- Build result: 5 errors, 11 warnings across 4 projects (report produced by cppupgrade_rebuild_and_get_issues)
+
+In-scope issues (to be fixed if you confirm)
+
+1) Project: C:\Users\matt\source\repos\3ll3d00d\mwcapture\common\common.vcxproj
+   - File: C:\Users\matt\source\repos\3ll3d00d\mwcapture\common\capture_filter.cpp
+     - Error C1083: Cannot open include file: 'quill/Backend.h' (line 16)
+     - Context: #include "quill/Backend.h"
+   - File: C:\Users\matt\source\repos\3ll3d00d\mwcapture\common\logging.h
+     - Error C1083: Cannot open include file: 'quill/Logger.h' (line 27)
+     - Context: #include <quill/Logger.h>
+   - File: C:\Users\matt\source\repos\3ll3d00d\mwcapture\common\signalinfo.cpp
+     - Warning C4267: conversion from 'size_t' to 'int' in calls to WideCharToMultiByte (lines ~40,47)
+     - Context: WideCharToMultiByte calls using input.size() (size_t) assigned to int
+
+2) Project: C:\Users\matt\source\repos\3ll3d00d\mwcapture\bmcapture\bmcapture.vcxproj
+   - File: C:\Users\matt\source\repos\3ll3d00d\mwcapture\common\logging.h
+     - Error C1083: Cannot open include file: 'quill/Logger.h' (line 27)
+   - Project-level warning MSB8074: Cannot read Module Dependencies file x64\Debug\bm_capture_filter.h.module.json (build order might be incorrect)
+
+3) Project: C:\Users\matt\source\repos\3ll3d00d\mwcapture\mwcapture-test\mwcapture-test.vcxproj
+   - File: C:\Users\matt\source\repos\3ll3d00d\mwcapture\mwcapture-test\test.cpp
+     - Error C1083: Cannot open include file: 'gtest/gtest.h' (line 3)
+     - Context: #include "gtest/gtest.h"
+
+4) Project: C:\Users\matt\source\repos\3ll3d00d\mwcapture\benchtest\benchtest.vcxproj
+   - File: C:\Users\matt\source\repos\3ll3d00d\mwcapture\benchtest\bench.cpp
+     - Warnings (C4244, C4267) related to narrowing conversions and size_t->int assignments at lines around 891, 983, 1036. Examples:
+       - "const uint16_t red_16 = (srcPixel & 0x3FF00000) >> 14;"
+       - "const int blocks = width / 4;"
+     - These are lower risk warnings but will be addressed to eliminate potential truncation and 64->32-bit issues.
+
+Root causes and immediate remediation options (high level)
+
+- Missing headers for external libraries:
+  - 'quill' headers missing: likely the quill logging library is not found by include paths after toolset upgrade or dependency not installed. Options:
+    1) Install or restore quill (vcpkg, submodule, or system install) and add its include path to project(s).
+    2) If the project intentionally builds without quill (e.g., NO_QUILL), add conditional compilation or replace quill usage with stub/no-op logger for test builds.
+  - 'gtest/gtest.h' missing: Google Test include not found. Options:
+    1) Install/restore Google Test (vcpkg or other) and add include/lib paths.
+    2) Exclude test project or build with NO_GTEST guard.
+
+- Warnings about integer narrowing and size conversions:
+  - Fix by using explicit casts where safe, or change variable types (use uint16_t, int32_t, or size_t appropriately) and/or perform range checks.
+
+- MSB8074 module.json read error:
+  - Could be caused by an out-of-date intermediate file produced by prior toolset or race in build order. Clearing the intermediate folder (x64\Debug) and rebuilding often resolves it. If it persists, we will inspect the indicated module.json file and the generating header to fix generation or build order.
+
+Out-of-scope (unless you instruct otherwise)
+
+- Any changes to third-party library source code (quill, gtest) beyond updating include paths or switching to installed package versions.
+- Large refactors unrelated to build errors (renaming, API design changes).
+
+Next steps
+
+- Confirm you want me to proceed to fix the in-scope issues listed above. Planned first steps on confirmation:
+  1) Attempt to restore/install missing dependencies (quill and gtest) or add include path adjustments (I will report and ask if you want me to install via vcpkg or rely on local SDKs).
+  2) Fix narrowing and size conversion warnings in "C:\Users\matt\source\repos\3ll3d00d\mwcapture\benchtest\bench.cpp" and "common\signalinfo.cpp" making minimal safe changes to types/casts.
+  3) Clean x64\Debug intermediate files and rebuild to resolve MSB8074; if it persists inspect module.json and generator.
+  4) Rebuild with cppupgrade_rebuild_and_get_issues to validate. I will produce a plan.md and tasks.md and then execute changes on a new branch if you approve.
+
+Please reply with "Proceed" to authorize fixes now, or reply with changes to scope. If you want me to use vcpkg to install dependencies, say "Use vcpkg".

--- a/benchtest/bench.cpp
+++ b/benchtest/bench.cpp
@@ -888,9 +888,9 @@ namespace
 				// r210 is simply BGR once swapped to little endian
 				const auto srcPixel = _byteswap_ulong(srcPixelBE[x]);
 
-				const uint16_t red_16 = (srcPixel & 0x3FF00000) >> 14;
-				const uint16_t green_16 = (srcPixel & 0xFFC00) >> 4;
-				const uint16_t blue_16 = (srcPixel & 0x3FF) << 6;
+                const uint16_t red_16 = static_cast<uint16_t>(((srcPixel) & 0x3FF00000u) >> 14);
+				const uint16_t green_16 = static_cast<uint16_t>(((srcPixel) & 0x000FFC00u) >> 4);
+				const uint16_t blue_16 = static_cast<uint16_t>(((srcPixel) & 0x000003FFu) << 6);
 
 				dstPix[0] = red_16;
 				dstPix[1] = green_16;
@@ -933,18 +933,18 @@ namespace
 				__m128i pixelBlockLE = _mm_shuffle_epi8(pixelBlockBE, pixelEndianSwap);
 				const uint32_t* p = reinterpret_cast<const uint32_t*>(&pixelBlockLE);
 
-				dstPix[0] = (p[0] & 0x3FF00000) >> 14; // red
-				dstPix[1] = (p[0] & 0xFFC00) >> 4; // green
-				dstPix[2] = (p[0] & 0x3FF) << 6; // blue
-				dstPix[3] = (p[1] & 0x3FF00000) >> 14;
-				dstPix[4] = (p[1] & 0xFFC00) >> 4;
-				dstPix[5] = (p[1] & 0x3FF) << 6;
-				dstPix[6] = (p[2] & 0x3FF00000) >> 14;
-				dstPix[7] = (p[2] & 0xFFC00) >> 4;
-				dstPix[8] = (p[2] & 0x3FF) << 6;
-				dstPix[9] = (p[3] & 0x3FF00000) >> 14;
-				dstPix[10] = (p[3] & 0xFFC00) >> 4;
-				dstPix[11] = (p[3] & 0x3FF) << 6;
+                dstPix[0] = static_cast<uint16_t>((p[0] & 0x3FF00000) >> 14); // red
+				dstPix[1] = static_cast<uint16_t>((p[0] & 0xFFC00) >> 4); // green
+				dstPix[2] = static_cast<uint16_t>((p[0] & 0x3FF) << 6); // blue
+				dstPix[3] = static_cast<uint16_t>((p[1] & 0x3FF00000) >> 14);
+				dstPix[4] = static_cast<uint16_t>((p[1] & 0xFFC00) >> 4);
+				dstPix[5] = static_cast<uint16_t>((p[1] & 0x3FF) << 6);
+				dstPix[6] = static_cast<uint16_t>((p[2] & 0x3FF00000) >> 14);
+				dstPix[7] = static_cast<uint16_t>((p[2] & 0xFFC00) >> 4);
+				dstPix[8] = static_cast<uint16_t>((p[2] & 0x3FF) << 6);
+				dstPix[9] = static_cast<uint16_t>((p[3] & 0x3FF00000) >> 14);
+				dstPix[10] = static_cast<uint16_t>((p[3] & 0xFFC00) >> 4);
+				dstPix[11] = static_cast<uint16_t>((p[3] & 0x3FF) << 6);
 				dstPix += 12;
 				srcPixelBE += 4;
 			}
@@ -980,7 +980,7 @@ namespace
 		const int dstPadding = padWidth * 6;
 
 		// process in 4 pixel (128 bit) blocks which produces 192 bits of output
-		const int blocks = width / 4;
+        const int blocks = static_cast<int>(width / 4);
 		*t1 = std::chrono::high_resolution_clock::now();
 		for (size_t y = 0; y < height; ++y)
 		{
@@ -1033,7 +1033,7 @@ namespace
 		const __m256i shift_R_B = _mm256_set1_epi32(0x00040040);
 		const __m256i mask_G = _mm256_set1_epi32(0x000FFC00);
 
-		const int blocks = width / 8;
+        const int blocks = static_cast<int>(width / 8);
 		const int dstPadding = padWidth * 6;
 		*t1 = std::chrono::high_resolution_clock::now();
 		for (size_t y = 0; y < height; ++y)

--- a/benchtest/benchtest.vcxproj
+++ b/benchtest/benchtest.vcxproj
@@ -38,40 +38,40 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>v143</PlatformToolset>
+    <PlatformToolset>v145</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>v143</PlatformToolset>
+    <PlatformToolset>v145</PlatformToolset>
     <WholeProgramOptimization>true</WholeProgramOptimization>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='ReleaseNoArch|Win32'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>v143</PlatformToolset>
+    <PlatformToolset>v145</PlatformToolset>
     <WholeProgramOptimization>true</WholeProgramOptimization>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>v143</PlatformToolset>
+    <PlatformToolset>v145</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>v143</PlatformToolset>
+    <PlatformToolset>v145</PlatformToolset>
     <WholeProgramOptimization>true</WholeProgramOptimization>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='ReleaseNoArch|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>v143</PlatformToolset>
+    <PlatformToolset>v145</PlatformToolset>
     <WholeProgramOptimization>true</WholeProgramOptimization>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>

--- a/bmcapture/bmcapture.vcxproj
+++ b/bmcapture/bmcapture.vcxproj
@@ -53,68 +53,68 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
     <ConfigurationType>DynamicLibrary</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>v143</PlatformToolset>
+    <PlatformToolset>v145</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
     <ConfigurationType>DynamicLibrary</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>v143</PlatformToolset>
+    <PlatformToolset>v145</PlatformToolset>
     <WholeProgramOptimization>true</WholeProgramOptimization>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='ReleaseNoArch|Win32'" Label="Configuration">
     <ConfigurationType>DynamicLibrary</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>v143</PlatformToolset>
+    <PlatformToolset>v145</PlatformToolset>
     <WholeProgramOptimization>true</WholeProgramOptimization>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='ReleaseTrace|Win32'" Label="Configuration">
     <ConfigurationType>DynamicLibrary</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>v143</PlatformToolset>
+    <PlatformToolset>v145</PlatformToolset>
     <WholeProgramOptimization>true</WholeProgramOptimization>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='ReleaseTraceNoArch|Win32'" Label="Configuration">
     <ConfigurationType>DynamicLibrary</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>v143</PlatformToolset>
+    <PlatformToolset>v145</PlatformToolset>
     <WholeProgramOptimization>true</WholeProgramOptimization>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
     <ConfigurationType>DynamicLibrary</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>v143</PlatformToolset>
+    <PlatformToolset>v145</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
     <ConfigurationType>DynamicLibrary</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>v143</PlatformToolset>
+    <PlatformToolset>v145</PlatformToolset>
     <WholeProgramOptimization>true</WholeProgramOptimization>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='ReleaseNoArch|x64'" Label="Configuration">
     <ConfigurationType>DynamicLibrary</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>v143</PlatformToolset>
+    <PlatformToolset>v145</PlatformToolset>
     <WholeProgramOptimization>true</WholeProgramOptimization>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='ReleaseTrace|x64'" Label="Configuration">
     <ConfigurationType>DynamicLibrary</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>v143</PlatformToolset>
+    <PlatformToolset>v145</PlatformToolset>
     <WholeProgramOptimization>true</WholeProgramOptimization>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='ReleaseTraceNoArch|x64'" Label="Configuration">
     <ConfigurationType>DynamicLibrary</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>v143</PlatformToolset>
+    <PlatformToolset>v145</PlatformToolset>
     <WholeProgramOptimization>true</WholeProgramOptimization>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>

--- a/bmcapture/vcpkg-configuration.json
+++ b/bmcapture/vcpkg-configuration.json
@@ -1,7 +1,7 @@
 {
   "default-registry": {
     "kind": "git",
-    "baseline": "4ff394902b5bc4e242fc17648a787d5ca016b6fd",
+    "baseline": "1e199d32ad53aab1defda61ce41c380302e3f95c",
     "repository": "https://github.com/microsoft/vcpkg"
   },
   "registries": [

--- a/common/common.vcxproj
+++ b/common/common.vcxproj
@@ -53,68 +53,68 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
     <ConfigurationType>StaticLibrary</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>v143</PlatformToolset>
+    <PlatformToolset>v145</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
     <ConfigurationType>StaticLibrary</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>v143</PlatformToolset>
+    <PlatformToolset>v145</PlatformToolset>
     <WholeProgramOptimization>true</WholeProgramOptimization>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='ReleaseNoArch|Win32'" Label="Configuration">
     <ConfigurationType>StaticLibrary</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>v143</PlatformToolset>
+    <PlatformToolset>v145</PlatformToolset>
     <WholeProgramOptimization>true</WholeProgramOptimization>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='ReleaseTrace|Win32'" Label="Configuration">
     <ConfigurationType>StaticLibrary</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>v143</PlatformToolset>
+    <PlatformToolset>v145</PlatformToolset>
     <WholeProgramOptimization>true</WholeProgramOptimization>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='ReleaseTraceNoArch|Win32'" Label="Configuration">
     <ConfigurationType>StaticLibrary</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>v143</PlatformToolset>
+    <PlatformToolset>v145</PlatformToolset>
     <WholeProgramOptimization>true</WholeProgramOptimization>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
     <ConfigurationType>StaticLibrary</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>v143</PlatformToolset>
+    <PlatformToolset>v145</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
     <ConfigurationType>StaticLibrary</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>v143</PlatformToolset>
+    <PlatformToolset>v145</PlatformToolset>
     <WholeProgramOptimization>true</WholeProgramOptimization>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='ReleaseNoArch|x64'" Label="Configuration">
     <ConfigurationType>StaticLibrary</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>v143</PlatformToolset>
+    <PlatformToolset>v145</PlatformToolset>
     <WholeProgramOptimization>true</WholeProgramOptimization>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='ReleaseTrace|x64'" Label="Configuration">
     <ConfigurationType>StaticLibrary</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>v143</PlatformToolset>
+    <PlatformToolset>v145</PlatformToolset>
     <WholeProgramOptimization>true</WholeProgramOptimization>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='ReleaseTraceNoArch|x64'" Label="Configuration">
     <ConfigurationType>StaticLibrary</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>v143</PlatformToolset>
+    <PlatformToolset>v145</PlatformToolset>
     <WholeProgramOptimization>true</WholeProgramOptimization>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>

--- a/common/signalinfo.cpp
+++ b/common/signalinfo.cpp
@@ -37,14 +37,19 @@ static std::string wstring_to_string(const std::wstring& input)
 		auto empty = std::string{};
 		return empty;
 	}
-	int size = WideCharToMultiByte(CP_ACP, 0, input.c_str(), input.size(), nullptr, 0, nullptr, nullptr);
+    int size = WideCharToMultiByte(CP_ACP, 0, input.c_str(), static_cast<int>(input.size()), nullptr, 0, nullptr, nullptr);
 	if (size <= 0)
 	{
 		auto empty = std::string{};
 		return empty;
 	}
-	std::vector<char> outChars(input.length() + 1);
-	if (WideCharToMultiByte(CP_ACP, 0, input.c_str(), input.size(), outChars.data(), size, nullptr, nullptr) <= 0)
+    if (size <= 0)
+	{
+		auto empty = std::string{};
+		return empty;
+	}
+	std::vector<char> outChars(static_cast<size_t>(size) + 1);
+	if (WideCharToMultiByte(CP_ACP, 0, input.c_str(), static_cast<int>(input.size()), outChars.data(), size, nullptr, nullptr) <= 0)
 	{
 		outChars.clear();
 		auto empty = std::string{};

--- a/common/vcpkg-configuration.json
+++ b/common/vcpkg-configuration.json
@@ -1,7 +1,7 @@
 {
   "default-registry": {
     "kind": "git",
-    "baseline": "4ff394902b5bc4e242fc17648a787d5ca016b6fd",
+    "baseline": "1e199d32ad53aab1defda61ce41c380302e3f95c",
     "repository": "https://github.com/microsoft/vcpkg"
   },
   "registries": [

--- a/common/vcpkg.json
+++ b/common/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "dependencies": [
     "quill",
-	"winreg"
+    "winreg"
   ]
 }

--- a/directshow_baseclasses/directshow_baseclasses.vcxproj
+++ b/directshow_baseclasses/directshow_baseclasses.vcxproj
@@ -109,40 +109,40 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
     <ConfigurationType>StaticLibrary</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>v143</PlatformToolset>
+    <PlatformToolset>v145</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
     <ConfigurationType>StaticLibrary</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>v143</PlatformToolset>
+    <PlatformToolset>v145</PlatformToolset>
     <WholeProgramOptimization>true</WholeProgramOptimization>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='ReleaseNoArch|Win32'" Label="Configuration">
     <ConfigurationType>StaticLibrary</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>v143</PlatformToolset>
+    <PlatformToolset>v145</PlatformToolset>
     <WholeProgramOptimization>true</WholeProgramOptimization>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
     <ConfigurationType>StaticLibrary</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>v143</PlatformToolset>
+    <PlatformToolset>v145</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
     <ConfigurationType>StaticLibrary</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>v143</PlatformToolset>
+    <PlatformToolset>v145</PlatformToolset>
     <WholeProgramOptimization>true</WholeProgramOptimization>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='ReleaseNoArch|x64'" Label="Configuration">
     <ConfigurationType>StaticLibrary</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>v143</PlatformToolset>
+    <PlatformToolset>v145</PlatformToolset>
     <WholeProgramOptimization>true</WholeProgramOptimization>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>

--- a/mwcapture-test/mwcapture-test.vcxproj
+++ b/mwcapture-test/mwcapture-test.vcxproj
@@ -31,7 +31,7 @@
     <Keyword>Win32Proj</Keyword>
     <WindowsTargetPlatformVersion>10.0.26100.0</WindowsTargetPlatformVersion>
     <ConfigurationType>Application</ConfigurationType>
-    <PlatformToolset>v143</PlatformToolset>
+    <PlatformToolset>v145</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />

--- a/mwcapture-test/vcpkg-configuration.json
+++ b/mwcapture-test/vcpkg-configuration.json
@@ -1,7 +1,7 @@
 {
   "default-registry": {
     "kind": "git",
-    "baseline": "4ff394902b5bc4e242fc17648a787d5ca016b6fd",
+    "baseline": "1e199d32ad53aab1defda61ce41c380302e3f95c",
     "repository": "https://github.com/microsoft/vcpkg"
   },
   "registries": [

--- a/mwcapture/mwcapture.vcxproj
+++ b/mwcapture/mwcapture.vcxproj
@@ -53,68 +53,68 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
     <ConfigurationType>DynamicLibrary</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>v143</PlatformToolset>
+    <PlatformToolset>v145</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
     <ConfigurationType>DynamicLibrary</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>v143</PlatformToolset>
+    <PlatformToolset>v145</PlatformToolset>
     <WholeProgramOptimization>true</WholeProgramOptimization>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='ReleaseNoArch|Win32'" Label="Configuration">
     <ConfigurationType>DynamicLibrary</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>v143</PlatformToolset>
+    <PlatformToolset>v145</PlatformToolset>
     <WholeProgramOptimization>true</WholeProgramOptimization>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='ReleaseTrace|Win32'" Label="Configuration">
     <ConfigurationType>DynamicLibrary</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>v143</PlatformToolset>
+    <PlatformToolset>v145</PlatformToolset>
     <WholeProgramOptimization>true</WholeProgramOptimization>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='ReleaseTraceNoArch|Win32'" Label="Configuration">
     <ConfigurationType>DynamicLibrary</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>v143</PlatformToolset>
+    <PlatformToolset>v145</PlatformToolset>
     <WholeProgramOptimization>true</WholeProgramOptimization>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
     <ConfigurationType>DynamicLibrary</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>v143</PlatformToolset>
+    <PlatformToolset>v145</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
     <ConfigurationType>DynamicLibrary</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>v143</PlatformToolset>
+    <PlatformToolset>v145</PlatformToolset>
     <WholeProgramOptimization>true</WholeProgramOptimization>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='ReleaseNoArch|x64'" Label="Configuration">
     <ConfigurationType>DynamicLibrary</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>v143</PlatformToolset>
+    <PlatformToolset>v145</PlatformToolset>
     <WholeProgramOptimization>true</WholeProgramOptimization>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='ReleaseTrace|x64'" Label="Configuration">
     <ConfigurationType>DynamicLibrary</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>v143</PlatformToolset>
+    <PlatformToolset>v145</PlatformToolset>
     <WholeProgramOptimization>true</WholeProgramOptimization>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='ReleaseTraceNoArch|x64'" Label="Configuration">
     <ConfigurationType>DynamicLibrary</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>v143</PlatformToolset>
+    <PlatformToolset>v145</PlatformToolset>
     <WholeProgramOptimization>true</WholeProgramOptimization>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>

--- a/mwcapture/vcpkg-configuration.json
+++ b/mwcapture/vcpkg-configuration.json
@@ -1,7 +1,7 @@
 {
   "default-registry": {
     "kind": "git",
-    "baseline": "4ff394902b5bc4e242fc17648a787d5ca016b6fd",
+    "baseline": "1e199d32ad53aab1defda61ce41c380302e3f95c",
     "repository": "https://github.com/microsoft/vcpkg"
   },
   "registries": [


### PR DESCRIPTION
Restores vcpkg dependencies (quill, gtest), fixes narrowing casts in bench.cpp and signalinfo.cpp, and includes plan/tasks (see assessment.md and .github/upgrades).